### PR TITLE
Add note for the repo change for the lecture 6

### DIFF
--- a/content/en/modules/git_github/index.md
+++ b/content/en/modules/git_github/index.md
@@ -42,6 +42,8 @@ All the tutorial notes are available [here](https://emdupre.github.io/git-course
 The video of her presentation is available below:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/fBgxmpk9C4I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+## ATTENTION! 
+For the last lecture of the Introduction to Git and GitHub module ([Pull Requests](https://emdupre.github.io/git-course/06-pull-requests/)) please use [this repo](https://github.com/brainhack-school2022/more-papers) under Brainhack School 2022 Github organization to complete the tutorial instead of the one indicated in the tutorial (due to it is no longer in use.). Thank you! 
 
 ## Exercise
 


### PR DESCRIPTION
The link in lecture 6 requires to work on @emdupre 's repository and requires her approval each time a PR is created, which would want to avoid. 

She is kindly happy for us to move forward to fork the repo to the BHS organization, for which I added a note to the module page. 